### PR TITLE
has_new_text should be True always, not only when players == 0

### DIFF
--- a/dbconnection.py
+++ b/dbconnection.py
@@ -637,7 +637,7 @@ class DatabaseConnector:
                 game = PickupGames.select().where(PickupGames.id == gid).first()
                 if len(game.addedplayers) == 0:
                     game.delete_instance()
-                    has_new_text = True
+                has_new_text = True
             elif pugdiff >= warntime:
                 if mindiff > deletetime - pugdiff:
                     mindiff = deletetime - pugdiff  


### PR DESCRIPTION
When a player has been removed due the timer the pickup topic and text should be updated, no matter whether the player count is 0 or not.