### PR TITLE
Multiline messages are splitted for IRC.

### DIFF
--- a/discordconnection.py
+++ b/discordconnection.py
@@ -141,7 +141,9 @@ async def on_message(message):
     
     if should_bridge:
         content = message.clean_content
-        bot.ircconnect.send_my_message("<%s> %s" % (message.author.name, content))
+        for line in content.splitlines():
+            if line.strip() != "":
+                bot.ircconnect.send_my_message("<%s> %s" % (message.author.name, line))
 
         for attachment in message.attachments:
             bot.ircconnect.send_my_message("URL: " + attachment.url)


### PR DESCRIPTION
Considered 2 possible solutions:

1. Handling it in `ircconnection.py`: It is not good because the user is not repeated.
2. Handling it in `discordconnecton.py`: It's better because we can repeat the username for each line.